### PR TITLE
fix: replace NuGetCommand with DotNetCoreCLI for package upload

### DIFF
--- a/azure-pipelines/production.yml
+++ b/azure-pipelines/production.yml
@@ -38,7 +38,7 @@ stages:
               versionEnvVar: Build.Version
 
           # upload package
-          - task: NuGetCommand@2
+          - task: DotNetCoreCLI@2
             displayName: Upload package to NuGet
             inputs:
               command: push


### PR DESCRIPTION
- production.yml
  - changed task from NuGetCommand@2 to DotNetCoreCLI@2 for uploading package to NuGet