### PR TITLE
fix: update arguments for packing NuGet package

### DIFF
--- a/azure-pipelines/production.yml
+++ b/azure-pipelines/production.yml
@@ -33,7 +33,7 @@ stages:
             displayName: Pack
             inputs:
               command: pack
-              arguments: '-c $(Build.BuildConfiguration) -p:Version="$(Build.Version)" -p:PackageVersion="$(Build.Version)"'
+              arguments: '-c $(Build.BuildConfiguration) -p:AssemblyVersion="$(Build.Version)" -p:FileVersion="$(Build.Version)" -p:InformationalVersion="$(Build.Version)" -p:Version="$(Build.Version)" -p:PackageVersion="$(Build.Version)"'
               packagesToPack: $(Build.BuildProjects)
               versioningScheme: byEnvVar
               versionEnvVar: Build.Version


### PR DESCRIPTION
azure-pipelines/production.yml
  - updated pack command arguments to include AssemblyVersion, FileVersion, and InformationalVersion