### PR TITLE
chore: update SHA256Pool method name for clarity

### DIFF
--- a/src/Utilities.Tron.AddressConverter/Extensions/StringExtensions.cs
+++ b/src/Utilities.Tron.AddressConverter/Extensions/StringExtensions.cs
@@ -42,7 +42,7 @@ public static class StringExtensions
 		}
 		finally
 		{
-			Sha256Pool.Return(sha256);
+			Sha256Pool.Release(sha256);
 		}
 
 		Span<byte> addressWithChecksum = stackalloc byte[25];

--- a/src/Utilities.Tron.AddressConverter/SHA256Pool.cs
+++ b/src/Utilities.Tron.AddressConverter/SHA256Pool.cs
@@ -17,10 +17,10 @@ public static class Sha256Pool
 	public static SHA256 Rent() => _pool.Get();
 
 	/// <summary>
-	/// Returns a <see cref="SHA256"/> instance to the pool.
+	/// Release a <see cref="SHA256"/> instance to the pool.
 	/// </summary>
 	/// <param name="sha256">The <see cref="SHA256"/> instance to return.</param>
-	public static void Return(SHA256 sha256) => _pool.Return(sha256);
+	public static void Release(SHA256 sha256) => _pool.Return(sha256);
 
 	private sealed class Sha256PooledObjectPolicy : PooledObjectPolicy<SHA256>
 	{


### PR DESCRIPTION
- SHA256Pool.cs
  - Rename method Return to Release for better clarity
- StringExtensions.cs
  - Update method call to use new Release method

close #3 